### PR TITLE
Fix scale.js issue #10

### DIFF
--- a/content/scale.js
+++ b/content/scale.js
@@ -14,7 +14,7 @@ function scale(e, setZoom, scrollX = window.scrollX, scrollY = window.scrollY) {
     zoom = setZoom;
 
     // scale before calculations if zooming in
-    if (zoom > oldZoom) body.style.setProperty('transform', 'scale(' + zoom + ')', 'important');
+    if (zoom > oldZoom) document.body.style.setProperty('transform', 'scale(' + zoom + ')', 'important');
 
     // scroll calculations - width
     const newClientWidth = html.clientWidth;
@@ -37,7 +37,7 @@ function scale(e, setZoom, scrollX = window.scrollX, scrollY = window.scrollY) {
     const offsetHeight = (oldHeight - newHeight) * zoom * mouseMultY + (oldClientHeight - newClientHeight);
 
     // scale after calculations if zooming out
-    if (zoom < oldZoom) body.style.setProperty('transform', 'scale(' + zoom + ')', 'important');
+    if (zoom < oldZoom) document.body.style.setProperty('transform', 'scale(' + zoom + ')', 'important');
 
     // scroll action
     window.scroll(startWidth + offsetWidth, startHeight + offsetHeight); // try deleting/commenting that line to see what happens without scrolling


### PR DESCRIPTION
fixes https://github.com/nizioleque/mouse-pinch-to-zoom/issues/10

For some reason, ChatGPT  https://chatgpt.com/  site seems to replace its `body` element somehow after loading or something like that. So the simple global variable `body` no longer links to the real document.

This is a simple fix. `body -> document.body`.

I don't know if we need the `body` global variable then.